### PR TITLE
add wikilabs/uni-link plugin

### DIFF
--- a/.github/workflows/cdi.yml
+++ b/.github/workflows/cdi.yml
@@ -21,12 +21,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '14.x'
       - run: npm install
       - run: npm run build
+        env:
+          TIDDLYWIKI_PLUGIN_PATH: ./wikilabs-pugins
       - name: Deploy
         if: github.event_name != 'pull_request' 
         uses: JamesIves/github-pages-deploy-action@v4

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "wikilabs-pugins"]
+	path = wikilabs-pugins
+	url = git@github.com:wikilabs/plugins.git

--- a/tiddlywiki.info
+++ b/tiddlywiki.info
@@ -14,7 +14,8 @@
         "tiddlywiki/codemirror-mode-x-tiddlywiki",
         "tiddlywiki/codemirror-mode-javascript",
         "tiddlywiki/codemirror-mode-css",
-        "tiddlywiki/codemirror-mode-xml"
+        "tiddlywiki/codemirror-mode-xml",
+        "wikilabs/uni-link"
     ],
     "themes": [
         "tiddlywiki/vanilla",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new submodule for "wikilabs-pugins" to enhance modularity and dependency management.
	- Added the "wikilabs/uni-link" module to TiddlyWiki for improved link management capabilities.

- **Chores**
	- Updated GitHub Actions workflow to include a new environment variable for streamlined plugin handling during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->